### PR TITLE
gitignore local environment settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 /spec/reports/
 /tmp/
 
+# Ignore local .env
+.env
+
 # rspec failure tracking
 .rspec_status


### PR DESCRIPTION
Local .env should be ignored so devs don't accidentally expose API keys.