### PR TITLE
make sorbet more flexible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
 end
 
 group :development do
-  gem "sorbet", "0.5.10932"
+  gem "sorbet", "~> 0.5"
 end
 
 group :development, :test do


### PR DESCRIPTION
Sorbet releases a new version very frequently and the dev gemfile is very strict about a specific minor number. 

It's better to losen the dependency.