### PR TITLE
Optimize GitHub workflows with bundler caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,12 +51,7 @@ jobs:
       uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651
       with:
         ruby-version: ${{ matrix.ruby }}
-
-    - name: Install dependencies
-      run: |
-        bundle config path vendor/bundle
-        bundle config --local without 'development'
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
 
     - name: Run the default task
       run: bundle exec rspec


### PR DESCRIPTION
## Summary
• Enable bundler caching in tests workflow to improve CI performance
• Remove manual gem installation in favor of built-in caching from ruby/setup-ruby action
• Streamline workflow configuration for consistency with lint workflow

## Test plan
- [ ] Verify workflows run successfully on PR
- [ ] Confirm faster build times with caching enabled
- [ ] Check that all Ruby matrix versions (3.2, 3.3, 3.4) work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)