### PR TITLE
Add rspec-github formatter for CI test annotations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,4 +54,4 @@ jobs:
         bundler-cache: true
 
     - name: Run the default task
-      run: bundle exec rspec
+      run: bundle exec rspec --format RSpec::Github::Formatter --format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 
 group :test do
   gem "rspec", "~> 3.0"
+  gem "rspec-github"
   gem "rspec-its"
   gem "simplecov", require: false
   gem "vcr"


### PR DESCRIPTION
## Summary
- Add rspec-github gem to provide GitHub Actions test annotations
- Configure CI to use both RSpec::Github::Formatter and documentation format
- Test failures will now appear as inline annotations on pull requests

## Test plan
- [ ] CI tests pass with new formatter configuration
- [ ] Verify annotations appear on test failures (if any)
- [ ] Documentation format output still visible in Actions logs