### PR TITLE
Add GitHub formatters for CI annotations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         bundler-cache: true
 
     - name: Run Rubocop
-      run: bundle exec rubocop
+      run: bundle exec rubocop --format github
 
   tapioca:
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem "rake", "~> 13.0"
   gem "rspec-sorbet"
   gem "rubocop", "~> 1.77"
+  gem "rubocop-github-annotations-formatter", require: false
   gem "rubocop-rspec", "~> 3.0"
   gem "tapioca", "~> 0.17.5", require: false
   gem "yard"


### PR DESCRIPTION
## Summary
- Added `rubocop-github-annotations-formatter` gem to enable inline RuboCop annotations in PRs
- Configured RuboCop CI workflow to use `--format github` flag for GitHub annotations
- RSpec GitHub formatter was already configured and working

## Why This Matters
No more clicking through to Actions logs\! Test failures and linting violations now appear as inline annotations directly in PR diffs where they happen. This transforms the CI experience by putting feedback exactly where you need it.

## Test Plan
- [x] Verified RuboCop runs locally with no offenses
- [x] Verified Sorbet type checking passes
- [x] Confirmed `--format github` is a valid RuboCop formatter option
- [x] RSpec formatter already configured with `RSpec::Github::Formatter`
- [ ] CI will validate formatters work correctly when this PR runs